### PR TITLE
fix: add type to quick replies

### DIFF
--- a/rasa_addons/core/channels/webchat.py
+++ b/rasa_addons/core/channels/webchat.py
@@ -73,6 +73,7 @@ class WebchatOutput(OutputChannel):
         for button in buttons:
             message["quick_replies"].append(
                 {
+                    "type": button["type"],
                     "content_type": "text",
                     "title": button["title"],
                     "payload": button["payload"],


### PR DESCRIPTION
the type field was missing, so rasa-webchat was not able to treat messages properly