### PR TITLE
Fix to quick replies

### DIFF
--- a/rasa_addons/core/channels/rest.py
+++ b/rasa_addons/core/channels/rest.py
@@ -38,7 +38,7 @@ class RestOutput(OutputChannel):
             "recipient_id": recipient_id,
             "text": text,
             "image": image,
-            "buttons": buttons,
+            "quick_replies": buttons,
             "attachment": attachment,
             "custom": custom,
         }
@@ -83,7 +83,7 @@ class RestOutput(OutputChannel):
         **kwargs: Any
     ) -> None:
         await self._persist_message(
-            self._message(recipient_id, text=text, quick_replies=buttons)
+            self._message(recipient_id, text=text, buttons=buttons)
         )
 
     async def send_custom_json(

--- a/rasa_addons/core/channels/rest.py
+++ b/rasa_addons/core/channels/rest.py
@@ -83,7 +83,7 @@ class RestOutput(OutputChannel):
         **kwargs: Any
     ) -> None:
         await self._persist_message(
-            self._message(recipient_id, text=text, buttons=buttons)
+            self._message(recipient_id, text=text, quick_replies=buttons)
         )
 
     async def send_custom_json(


### PR DESCRIPTION
The messages produced for quick replies should be compatible with the Rasa webchat.